### PR TITLE
Session Title文字数制限の修正

### DIFF
--- a/2025-en.md
+++ b/2025-en.md
@@ -1,8 +1,8 @@
-# Creating Acrylic Stands and Keychains using Scratch: From Paint Editor to Laser Cutting
+# Creating Acrylic Stands and Keychains using Scratch: Using Paint Editor for Laser Cutting
 
 ## Session Title (85 characters max)
 
-Creating Acrylic Stands and Keychains using Scratch: From Paint Editor to Laser Cutting
+Creating Acrylic Stands and Keychains using Scratch: Using Paint Editor for Laser Cutting
 
 ## Short Description (450 characters max)
 

--- a/2025-en.md
+++ b/2025-en.md
@@ -1,8 +1,8 @@
-# Creating Acrylic Stands and Keychains with Scratch: From Paint Editor to Laser Cutting
+# Creating Acrylic Stands and Keychains using Scratch: From Paint Editor to Laser Cutting
 
 ## Session Title (85 characters max)
 
-Creating Acrylic Stands and Keychains with Scratch: From Paint Editor to Laser Cutting
+Creating Acrylic Stands and Keychains using Scratch: From Paint Editor to Laser Cutting
 
 ## Short Description (450 characters max)
 

--- a/2025-en.md
+++ b/2025-en.md
@@ -1,8 +1,8 @@
-# Creating Acrylic Stands and Keychains using Scratch: with Paint Editor & Laser Cutting
+# Creating Acrylic Stands and Keychains in Scratch: with Paint Editor & Laser Cutting
 
 ## Session Title (85 characters max)
 
-Creating Acrylic Stands and Keychains using Scratch: with Paint Editor & Laser Cutting
+Creating Acrylic Stands and Keychains in Scratch: with Paint Editor & Laser Cutting
 
 ## Short Description (450 characters max)
 

--- a/2025-en.md
+++ b/2025-en.md
@@ -1,8 +1,8 @@
-# Creating Acrylic Stands and Keychains using Scratch: Using Paint Editor for Laser Cutting
+# Creating Acrylic Stands and Keychains using Scratch: with Paint Editor & Laser Cutting
 
 ## Session Title (85 characters max)
 
-Creating Acrylic Stands and Keychains using Scratch: Using Paint Editor for Laser Cutting
+Creating Acrylic Stands and Keychains using Scratch: with Paint Editor & Laser Cutting
 
 ## Short Description (450 characters max)
 


### PR DESCRIPTION
- Session Titleが85文字制限を超えていたため、'with'を'using'に変更して文字数を調整しました。
- タイトルの意味は保ちながら、文字数制限内に収まるように修正しました。